### PR TITLE
Ckrivacic/input refactoring

### DIFF
--- a/pull_into_place/commands/01_setup_workspace.py
+++ b/pull_into_place/commands/01_setup_workspace.py
@@ -74,6 +74,7 @@ class CopyWorkspaceInputs:
 
     @staticmethod
     def install(workspace, old_workspace):
+        old_workspace = ensure_path_exists(old_workspace)
         old_workspace = pipeline.Workspace(old_workspace)
         old_workspace.check_paths()
         from distutils.dir_util import copy_tree
@@ -349,6 +350,14 @@ Design '{0}' already exists.  Use '-o' to overwrite.""", workspace.root_dir)
                 LoopsFile,
                 Resfile,
                 RestraintsFile,
+                ScoreFunction,
+                BuildScript,
+                DesignScript,
+                ValidateScript,
+                FilterScript,
+                SharedDefs,
+                FlagsFile,
+                FragmentWeights,
         )
 
     # Get the necessary settings from the user and use them to fill in the

--- a/pull_into_place/commands/01_setup_workspace.py
+++ b/pull_into_place/commands/01_setup_workspace.py
@@ -8,7 +8,8 @@ given below.  This information is used to build a workspace for this design
 that will be used by the rest of the scripts in this pipeline.
 
 Usage:
-    pull_into_place 01_setup_workspace <workspace> [--remote] [--overwrite]
+    pull_into_place 01_setup_workspace <workspace> [--remote]
+    [--overwrite] [--copy]
 
 Options:
     --remote, -r
@@ -19,6 +20,10 @@ Options:
     --overwrite, -o
         If a design with the given name already exists, remove it and replace
         it with the new design created by this script.
+
+    --copy, -c
+        Setup a workspace with the same inputs as a previously set-up
+        workspace.
 """
 
 import os, re, shutil, subprocess
@@ -62,6 +67,22 @@ the symlink called 'rosetta' in the workspace directory."""
 
         os.symlink(rosetta_dir, workspace.rosetta_dir)
 
+class CopyWorkspaceInputs:
+    prompt="Path to previous workspace: "
+    description = """\
+            Copying inputs from previous workspace."""
+
+    @staticmethod
+    def install(workspace, old_workspace):
+        old_workspace = pipeline.Workspace(old_workspace)
+        old_workspace.check_paths()
+        from distutils.dir_util import copy_tree
+        copy_tree(old_workspace.rosetta_inputs_dir(True),
+                workspace.rosetta_inputs_dir(True), preserve_symlinks =
+                True)
+        copy_tree(old_workspace.rosetta_inputs_dir(False),
+                workspace.rosetta_inputs_dir(False), preserve_symlinks =
+                True)
 
 class InputPdb:
     prompt = "Path to the input PDB file: "
@@ -317,6 +338,10 @@ Design '{0}' already exists.  Use '-o' to overwrite.""", workspace.root_dir)
                 RosettaDir,
                 RsyncUrl,
         )
+    elif arguments['--copy']:
+        installers = (
+                CopyWorkspaceInputs,
+                )
     else:
         installers = (
                 RosettaDir,
@@ -324,14 +349,6 @@ Design '{0}' already exists.  Use '-o' to overwrite.""", workspace.root_dir)
                 LoopsFile,
                 Resfile,
                 RestraintsFile,
-                ScoreFunction,
-                BuildScript,
-                DesignScript,
-                ValidateScript,
-                FilterScript,
-                SharedDefs,
-                FlagsFile,
-                FragmentWeights,
         )
 
     # Get the necessary settings from the user and use them to fill in the

--- a/pull_into_place/pipeline.py
+++ b/pull_into_place/pipeline.py
@@ -229,9 +229,17 @@ Expected to find a file matching '{0}'.  Did you forget to compile rosetta?
         in the directory associated with that stage.
         """
 
-        custom_path = os.path.join(self.focus_dir, basename)
-        default_path = os.path.join(self.root_dir, basename)
-        return custom_path if os.path.exists(custom_path) else default_path
+        custom_focus_path = os.path.join(self.focus_dir, basename)
+        custom_root_path = os.path.join(self.root_dir, 'custom_inputs',
+                basename)
+        default_path = os.path.join(self.root_dir, 'default_inputs', basename)
+
+        if os.path.exists(custom_focus_path):
+            return custom_fucos_path
+        elif os.path.exists(custom_root_path):
+            return custom_root_path
+        else:
+            return default_path
 
     def check_paths(self):
         required_paths = [

--- a/pull_into_place/pipeline.py
+++ b/pull_into_place/pipeline.py
@@ -59,6 +59,10 @@ class Workspace (object):
         return os.path.normpath(
                 os.path.join(self._root_dirname, self._root_basename))
 
+    def inputs_dir(self, default=True):
+        return os.path.join(self.root_dir, 'default_inputs' if default
+                else 'custom_inputs')
+
     @property
     def abs_root_dir(self):
         return os.path.abspath(self.root_dir)
@@ -230,12 +234,12 @@ Expected to find a file matching '{0}'.  Did you forget to compile rosetta?
         """
 
         custom_focus_path = os.path.join(self.focus_dir, basename)
-        custom_root_path = os.path.join(self.root_dir, 'custom_inputs',
+        custom_root_path = os.path.join(self.inputs_dir(False),
                 basename)
-        default_path = os.path.join(self.root_dir, 'default_inputs', basename)
+        default_path = os.path.join(self.inputs_dir(), basename)
 
         if os.path.exists(custom_focus_path):
-            return custom_fucos_path
+            return custom_focus_path
         elif os.path.exists(custom_root_path):
             return custom_root_path
         else:
@@ -273,6 +277,7 @@ Expected to find a file matching '{0}'.  Did you forget to compile rosetta?
 
     def make_dirs(self):
         scripting.mkdir(self.focus_dir)
+        scripting.mkdir(self.inputs_dir())
 
         pickle_path = os.path.join(self.focus_dir, 'workspace.pkl')
         with open(pickle_path, 'w') as file:

--- a/pull_into_place/pipeline.py
+++ b/pull_into_place/pipeline.py
@@ -278,6 +278,7 @@ Expected to find a file matching '{0}'.  Did you forget to compile rosetta?
     def make_dirs(self):
         scripting.mkdir(self.focus_dir)
         scripting.mkdir(self.inputs_dir())
+        scripting.mkdir(self.inputs_dir(False))
 
         pickle_path = os.path.join(self.focus_dir, 'workspace.pkl')
         with open(pickle_path, 'w') as file:

--- a/pull_into_place/pipeline.py
+++ b/pull_into_place/pipeline.py
@@ -59,9 +59,10 @@ class Workspace (object):
         return os.path.normpath(
                 os.path.join(self._root_dirname, self._root_basename))
 
-    def inputs_dir(self, default=True):
-        return os.path.join(self.root_dir, 'default_inputs' if default
-                else 'custom_inputs')
+    def rosetta_inputs_dir(self, default=True):
+        return os.path.normpath(os.path.join(self.root_dir, 
+                'default_inputs' if default
+                else 'custom_inputs'))
 
     @property
     def abs_root_dir(self):
@@ -234,9 +235,9 @@ Expected to find a file matching '{0}'.  Did you forget to compile rosetta?
         """
 
         custom_focus_path = os.path.join(self.focus_dir, basename)
-        custom_root_path = os.path.join(self.inputs_dir(False),
+        custom_root_path = os.path.join(self.rosetta_inputs_dir(False),
                 basename)
-        default_path = os.path.join(self.inputs_dir(), basename)
+        default_path = os.path.join(self.rosetta_inputs_dir(), basename)
 
         if os.path.exists(custom_focus_path):
             return custom_focus_path
@@ -277,8 +278,8 @@ Expected to find a file matching '{0}'.  Did you forget to compile rosetta?
 
     def make_dirs(self):
         scripting.mkdir(self.focus_dir)
-        scripting.mkdir(self.inputs_dir())
-        scripting.mkdir(self.inputs_dir(False))
+        scripting.mkdir(self.rosetta_inputs_dir())
+        scripting.mkdir(self.rosetta_inputs_dir(False))
 
         pickle_path = os.path.join(self.focus_dir, 'workspace.pkl')
         with open(pickle_path, 'w') as file:

--- a/pull_into_place/pipeline.py
+++ b/pull_into_place/pipeline.py
@@ -59,14 +59,17 @@ class Workspace (object):
         return os.path.normpath(
                 os.path.join(self._root_dirname, self._root_basename))
 
-    def rosetta_inputs_dir(self, default=True):
-        return os.path.normpath(os.path.join(self.root_dir, 
-                'default_inputs' if default
-                else 'custom_inputs'))
-
     @property
     def abs_root_dir(self):
         return os.path.abspath(self.root_dir)
+
+    @property
+    def focus_name(self):
+        """
+        The "name" of the directory managed by this class, e.g. for finding 
+        input files.  This is meant to be overridden in subclasses.
+        """
+        return ''
 
     @property
     def focus_dir(self):
@@ -226,25 +229,38 @@ Expected to find a file matching '{0}'.  Did you forget to compile rosetta?
         """
         Look in a few places for a file with the given name.  If a custom
         version of the file is found in the directory being managed by
-        this workspace, return it.  Otherwise return the path to the default
-        version of the file in the root directory.
+        this workspace, return it.  Otherwise look in the custom and default 
+        input directories in the root directory, and then finally in the root 
+        directory itself.
 
         This function makes it easy to provide custom parameters to any stage
         to the design pipeline.  Just place the file with the custom parameters
-        in the directory associated with that stage.
+        in a directory associated with that stage.
         """
 
-        custom_focus_path = os.path.join(self.focus_dir, basename)
-        custom_root_path = os.path.join(self.rosetta_inputs_dir(False),
-                basename)
-        default_path = os.path.join(self.rosetta_inputs_dir(), basename)
+        paths = [
+                os.path.join(self.focus_dir, basename),
+                os.path.join(self.root_dir, 'custom_inputs', self.focus_name, basename),
+                os.path.join(self.root_dir, 'custom_inputs', basename),
+                os.path.join(self.root_dir, 'default_inputs', self.focus_name, basename),
+                os.path.join(self.root_dir, 'default_inputs', basename),
+                os.path.join(self.root_dir, basename),
+        ]
 
-        if os.path.exists(custom_focus_path):
-            return custom_focus_path
-        elif os.path.exists(custom_root_path):
-            return custom_root_path
-        else:
-            return default_path
+        # Remove duplicate paths.  If there's any ambiguity, the lowest 
+        # priority duplicate is kept.  This is necessary to get the search 
+        # order for the root directory correct.
+        paths = sorted(
+                set(paths),
+                key=lambda x: max(i for i, path in enumerate(paths) if x == path)
+        )
+
+        for path in paths:
+            if os.path.exists(path):
+                return path
+
+        # Return the last path we checked, even though we didn't find the file.
+        return paths[-1]
 
     def check_paths(self):
         required_paths = [
@@ -278,8 +294,6 @@ Expected to find a file matching '{0}'.  Did you forget to compile rosetta?
 
     def make_dirs(self):
         scripting.mkdir(self.focus_dir)
-        scripting.mkdir(self.rosetta_inputs_dir())
-        scripting.mkdir(self.rosetta_inputs_dir(False))
 
         pickle_path = os.path.join(self.focus_dir, 'workspace.pkl')
         with open(pickle_path, 'w') as file:
@@ -497,8 +511,12 @@ class RestrainedModels (BigJobWorkspace, WithFragmentLibs):
         return RestrainedModels(os.path.join(directory, '..'))
 
     @property
+    def focus_name(self):
+        return os.path.join(self.root_dir, 'restrained_models')
+
+    @property
     def focus_dir(self):
-        return os.path.join(self.root_dir, '01_restrained_models')
+        return os.path.join(self.root_dir, '01_{0}'.format(self.focus_name))
 
     @property
     def input_dir(self):
@@ -529,10 +547,14 @@ class FixbbDesigns (BigJobWorkspace):
             return ValidatedDesigns(self.root_dir, self.round - 1)
 
     @property
+    def focus_name(self):
+        return 'fixbb_designs'
+
+    @property
     def focus_dir(self):
         assert self.round > 0
         prefix = 2 * self.round
-        subdir = '{0:02}_fixbb_designs_round_{1}'.format(prefix, self.round)
+        subdir = '{0:02}_{1}_round_{2}'.format(prefix, self.focus_name, self.round)
         return os.path.join(self.root_dir, subdir)
 
 
@@ -553,10 +575,14 @@ class ValidatedDesigns (BigJobWorkspace, WithFragmentLibs):
         return FixbbDesigns(self.root_dir, self.round)
 
     @property
+    def focus_name(self):
+        return 'validated_designs'
+
+    @property
     def focus_dir(self):
         assert self.round > 0
         prefix = 2 * self.round + 1
-        subdir = '{0:02}_validated_designs_round_{1}'.format(prefix, self.round)
+        subdir = '{0:02}_{1}_round_{2}'.format(prefix, self.focus_name, self.round)
         return os.path.join(self.root_dir, subdir)
 
     @property


### PR DESCRIPTION
New input behavior (this was much easier than I thought, thanks to your insistence on never hardcoding paths):

First, search focus_dir for input. There is no focus_dir/custom_inputs directory, which I think we discussed, because I figure there won't be many files here. We can change this if you want. 
Second, search root_dir/custom_inputs. 
Third, search root_dir/default_inputs. 

Also, you can now do pull_into_place 01 <workspace> --copy/-c, and the only prompt you will have to provide is the path to the previous workspace. This will copy root_dir/default_inputs and root_dir/custom_inputs, but not any focus_dir inputs. This can also be done, but I don't really like the idea of making the focus directories right off the bat, especially since we don't know how many rounds a user will go through. 

Things to improve:
- input.pdb.gz, loops, resfile, restraints file are all sort of "custom inputs" by nature. I kind of think default_inputs should be reserved for files that actually have a default (scripts, scorefxn, weights), but I think I'll have to increase the complexity of find_path() by quite a bit. 
- On that note, right now the installers always put things in the default_inputs directory. They should probably not do that for any files the user provides. 

I could introduce a "custom" variable to each of the path properties that forces it to go into the custom_inputs folder, but I'd like to get your thoughts before I do that since it's a bit tedious. 